### PR TITLE
Fix add to cart to store multiple items

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,10 +1,12 @@
-import { setLocalStorage } from "./utils.mjs";
+import { setLocalStorage, getLocalStorage } from "./utils.mjs";
 import ProductData from "./ProductData.mjs";
 
 const dataSource = new ProductData("tents");
 
 function addProductToCart(product) {
-  setLocalStorage("so-cart", product);
+  const cartItems = getLocalStorage("so-cart") || [];
+  cartItems.push(product);
+  setLocalStorage("so-cart", cartItems);
 }
 // add to cart button event handler
 async function addToCartHandler(e) {


### PR DESCRIPTION
I've fixed the "add to cart" function so that it adds items one after another and doesn't overwrite the existing item.